### PR TITLE
use JSON:API compliant query param name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,21 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.3]
 
-Unreleased
-
-### Added
+2021-03-10
 
 ### Changed
 
-### Deprecated
-
-### Removed
+- Defaults for fetch specification parameters have been cleaned up for
+  consistency and by adding typing where missing.
 
 ### Fixed
+
+- Handling of included resources is now done through the `include` query param,
+  as per JSON:API specification.
+
+- More `"`-wrapping of entity and prop names introduced erroneously in previous
+  release was undone. There are no instances left of this bug in the current
+  code.
 
 
 ## [0.4.2]

--- a/src/base.service.ts
+++ b/src/base.service.ts
@@ -116,7 +116,7 @@ export abstract class BaseService<Entity extends object, CreateModel, UpdateMode
     const idColumn = typeof idProperty === 'string' && idProperty.length > 0 ? idProperty : 'id';
     const query = this.repository.createQueryBuilder(this.alias);
     const queryWithFilters = this.setFiltersGetById(query, info, idProperty);
-    queryWithFilters.andWhere(`"${this.alias}"."${idColumn}" = :id`).setParameter('id', id);
+    queryWithFilters.andWhere(`${this.alias}.${idColumn} = :id`).setParameter('id', id);
     const model = await queryWithFilters.getOne();
     if (!model) {
       throw new NotFoundException(`${this.alias} not found.`);

--- a/src/config/default.config.ts
+++ b/src/config/default.config.ts
@@ -1,7 +1,20 @@
-import { PaginationSpecification } from '../types/fetch-specification.interface';
+import {
+  FieldsAndIncludesSpecification,
+  PaginationSpecification,
+  SortSpecification,
+} from '../types/fetch-specification.interface';
 
 export const DEFAULT_PAGINATION: PaginationSpecification = {
   pageSize: 25,
   pageNumber: 1,
   disablePagination: false,
+};
+
+export const DEFAULT_FIELDS_AND_INCLUDE_SPECIFICATION: FieldsAndIncludesSpecification = {
+  fields: [],
+  include: [],
+};
+
+export const DEFAULT_SORT_SPECIFICATION: SortSpecification = {
+  sort: [],
 };

--- a/src/middleware/fetch-specification.middleware.ts
+++ b/src/middleware/fetch-specification.middleware.ts
@@ -47,10 +47,10 @@ export class FetchSpecificationMiddleware implements NestMiddleware {
     // }
 
     /**
-     * @todo Possibly reinstate whitelisting of allowed includes, e.g.
+     * @todo Possibly reinstate whitelisting of allowed included entities, e.g.
      * (...).filter(inc => prePagination.allowIncludes.indexOf(inc) >= 0);
      */
-    fetchSpecification.includes = req?.query?.includes?.split(',');
+    fetchSpecification.include = req?.query?.include?.split(',');
 
     /**
      * @debt We are already interpreting `+` and `-` prefixes in
@@ -83,7 +83,7 @@ export class FetchSpecificationMiddleware implements NestMiddleware {
     delete req?.query?.omitFields;
     delete req?.query?.page;
     delete req?.query?.sort;
-    delete req?.query?.includes;
+    delete req?.query?.include;
     delete req?.query?.disablePagination;
 
     if (!req.fetchSpecification) {

--- a/src/middleware/fetch-specification.middleware.ts
+++ b/src/middleware/fetch-specification.middleware.ts
@@ -1,19 +1,11 @@
 import { NestMiddleware, Injectable, Logger } from '@nestjs/common';
-import { DEFAULT_PAGINATION } from '../config/default.config';
+import {
+  DEFAULT_FIELDS_AND_INCLUDE_SPECIFICATION,
+  DEFAULT_PAGINATION,
+  DEFAULT_SORT_SPECIFICATION,
+} from '../config/default.config';
 import { parseInt } from 'lodash';
 import { FetchSpecification } from 'types/fetch-specification.interface';
-
-const defaultFetchSpec = {
-  fields: [],
-  includes: [],
-  sort: [],
-};
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
-class ConfigPagination {
-  includes?: string[] = [];
-  allowIncludes?: string[] = [];
-}
 
 /**
  * The job of FetchSpecificationMiddleware is to reflect fetch specification
@@ -22,10 +14,10 @@ class ConfigPagination {
 @Injectable()
 export class FetchSpecificationMiddleware implements NestMiddleware {
   use(req: any, _res: any, next: () => void): any {
-    Logger.debug('Reflecting fetch specification metadata from query params to request object');
     const fetchSpecification: FetchSpecification = {
       ...DEFAULT_PAGINATION,
-      ...defaultFetchSpec,
+      ...DEFAULT_FIELDS_AND_INCLUDE_SPECIFICATION,
+      ...DEFAULT_SORT_SPECIFICATION,
       ...req.query,
     };
 

--- a/src/types/fetch-specification.interface.ts
+++ b/src/types/fetch-specification.interface.ts
@@ -7,7 +7,7 @@ export interface PaginationSpecification {
 export interface FieldsAndIncludesSpecification {
   fields?: string[];
   omitFields?: string[];
-  includes?: string[];
+  include?: string[];
 }
 
 export interface SortSpecification {

--- a/src/utils/fetch.utils.ts
+++ b/src/utils/fetch.utils.ts
@@ -19,7 +19,7 @@ export class FetchUtils<T> {
     {
       fields = undefined,
       omitFields = undefined,
-      includes = undefined,
+      include = undefined,
       pageNumber = DEFAULT_PAGINATION.pageNumber,
       pageSize = DEFAULT_PAGINATION.pageSize,
       disablePagination = DEFAULT_PAGINATION.disablePagination,
@@ -27,7 +27,7 @@ export class FetchUtils<T> {
     }: FetchSpecification = {
       fields: undefined,
       omitFields: undefined,
-      includes: undefined,
+      include: undefined,
       pageNumber: DEFAULT_PAGINATION.pageNumber,
       pageSize: DEFAULT_PAGINATION.pageSize,
       disablePagination: DEFAULT_PAGINATION.disablePagination,
@@ -38,7 +38,7 @@ export class FetchUtils<T> {
       `Applying fetch specification: ${inspect({
         fields,
         omitFields,
-        includes,
+        include,
         pageNumber,
         pageSize,
         disablePagination,
@@ -46,7 +46,7 @@ export class FetchUtils<T> {
       })}`
     );
 
-    const queryWithIncludedEntities = this.addIncludedEntities(query, aliasTable, { includes });
+    const queryWithIncludedEntities = this.addIncludedEntities(query, aliasTable, { include });
     const queryWithSparseFieldsets = this.addFields(queryWithIncludedEntities, aliasTable, {
       fields,
     });
@@ -95,15 +95,15 @@ export class FetchUtils<T> {
   static addIncludedEntities<T>(
     query: SelectQueryBuilder<T>,
     aliasTable: string,
-    { includes = undefined }: Pick<FetchSpecification, 'includes'> = {
-      includes: undefined,
+    { include = undefined }: Pick<FetchSpecification, 'include'> = {
+      include: undefined,
     }
   ) {
     /**
      * Select entities to be included as per fetch specification.
      */
-    if (includes && includes.length > 0) {
-      includes.forEach((inc) => {
+    if (include && include.length > 0) {
+      include.forEach((inc) => {
         const parts = inc.split('.');
         let lastPart = null;
         let completed = '';
@@ -114,18 +114,18 @@ export class FetchUtils<T> {
             }
             completed += element;
             const alias = completed.replace('.', '_');
-            if (includes.indexOf(completed) === -1 || completed === inc) {
+            if (include.indexOf(completed) === -1 || completed === inc) {
               if (index === 0) {
-                query.leftJoinAndSelect(`"${aliasTable}"."${element}"`, alias);
+                query.leftJoinAndSelect(`${aliasTable}.${element}`, alias);
               } else {
-                query.leftJoinAndSelect(`"${lastPart}"."${element}"`, alias);
+                query.leftJoinAndSelect(`${lastPart}.${element}`, alias);
               }
             }
 
             lastPart = alias;
           });
         } else {
-          query.leftJoinAndSelect(`"${aliasTable}"."${inc}"`, inc);
+          query.leftJoinAndSelect(`${aliasTable}.${inc}`, inc);
         }
       });
     }

--- a/src/utils/fetch.utils.ts
+++ b/src/utils/fetch.utils.ts
@@ -149,7 +149,7 @@ export class FetchUtils<T> {
         // if the first character is '-', sort descending; otherwise, sort
         // ascending
         const sortDirection: SortDirection = s.match(/^-/) ? 'DESC' : 'ASC';
-        query.addOrderBy(`"${aliasTable}"."${sortByColumn}"`, sortDirection);
+        query.addOrderBy(`${aliasTable}.${sortByColumn}`, sortDirection);
       });
     }
 


### PR DESCRIPTION
- fixed: use `include` instead of `includes`
- removed some leftover `"`-wrapping of entity/param names in TypeORM use
- cleaned up fetch specification defaults for consistency, and by adding typing where missing